### PR TITLE
Add dry_run parameter to Radio class

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,12 @@ print(latest)
     - HOST: `sts`
     - PORT: `9001`
     - TIMEOUT: `5.0` seconds
+    - DRY_RUN: `False`
 - You can override these via the constructor:
-    - `Radio(host='example.org', port=9001, timeout=2.0)`
+    - `Radio(host='example.org', port=9001, timeout=2.0, dry_run=True)`
+- You can also override `dry_run` for individual calls:
+    - `radio.transmit(data, dry_run=True)`
+    - `radio.receive(ids, dry_run=True)`
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ print(latest)
     - DRY_RUN: `False`
 - You can override these via the constructor:
     - `Radio(host='example.org', port=9001, timeout=2.0, dry_run=True)`
-- You can also override `dry_run` for individual calls:
+- You can also override `dry_run` for individual transmit calls:
     - `radio.transmit(data, dry_run=True)`
-    - `radio.receive(ids, dry_run=True)`
 
 ## Tests
 

--- a/src/subaru/sts/client/radio.py
+++ b/src/subaru/sts/client/radio.py
@@ -73,20 +73,15 @@ class Radio:
         finally:
             sock.close()
 
-    def receive(self, ids, dry_run=None):
+    def receive(self, ids):
         """Retrieve latest STS data from the STS board.
 
         Argument
             ids: Sequence of STS radio IDs
-            dry_run: Optional override to skip network operations
 
         Result
             List of Datum objects
         """
-        is_dry_run = dry_run if dry_run is not None else self.dry_run
-        if is_dry_run:
-            return []
-
         data = []
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:

--- a/src/subaru/sts/client/radio.py
+++ b/src/subaru/sts/client/radio.py
@@ -17,30 +17,39 @@ class Radio:
     # Default timeout (seconds)
     TIMEOUT = 5.0
 
-    def __init__(self, host=HOST, port=PORT, timeout=TIMEOUT):
+    def __init__(self, host=HOST, port=PORT, timeout=TIMEOUT, dry_run=False):
         """Create a Radio object.
 
         Arguments
             host: Domain name or IP address of the STS server
             port: TCP port number that the STS board listens to
             timeout: Network socket timeout in seconds
+            dry_run: If True, skip network operations
         """
         self.host = host
         self.port = port
         self.timeout = timeout
+        self.dry_run = dry_run
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(host={self.host!r}, port={self.port!r}, timeout={self.timeout!r})"
+        return f"{self.__class__.__name__}(host={self.host!r}, port={self.port!r}, timeout={self.timeout!r}, dry_run={self.dry_run!r})"
 
-    def transmit(self, data):
+    def transmit(self, data, dry_run=None):
         """Send STS data to the STS board.
 
         Argument
             data: Sequence of Datum objects
+            dry_run: Optional override to skip network operations
 
         Result
             None
         """
+        is_dry_run = dry_run if dry_run is not None else self.dry_run
+        if is_dry_run:
+            for datum in data:
+                Radio.pack(datum)
+            return
+
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.settimeout(self.timeout)
@@ -64,15 +73,20 @@ class Radio:
         finally:
             sock.close()
 
-    def receive(self, ids):
+    def receive(self, ids, dry_run=None):
         """Retrieve latest STS data from the STS board.
 
         Argument
             ids: Sequence of STS radio IDs
+            dry_run: Optional override to skip network operations
 
         Result
             List of Datum objects
         """
+        is_dry_run = dry_run if dry_run is not None else self.dry_run
+        if is_dry_run:
+            return []
+
         data = []
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -844,22 +844,6 @@ class TestRadioDryRun:
         mock_socket_class.assert_not_called()
 
     @patch("socket.socket")
-    def test_receive_dry_run_class_level(self, mock_socket_class, sample_ids):
-        """Test receive with dry_run enabled at class level."""
-        radio = Radio(dry_run=True)
-        data = radio.receive(sample_ids)
-        assert data == []
-        mock_socket_class.assert_not_called()
-
-    @patch("socket.socket")
-    def test_receive_dry_run_method_override(self, mock_socket_class, sample_ids):
-        """Test receive with dry_run enabled via method override."""
-        radio = Radio(dry_run=False)
-        data = radio.receive(sample_ids, dry_run=True)
-        assert data == []
-        mock_socket_class.assert_not_called()
-
-    @patch("socket.socket")
     def test_transmit_dry_run_invalid_data(self, mock_socket_class):
         """Test transmit with dry_run still validates data."""
         radio = Radio(dry_run=True)

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -71,13 +71,13 @@ class TestRadioInit:
     def test_repr(self):
         """Test __repr__ method."""
         radio = Radio(host="testhost", port=1234, timeout=2.5)
-        expected = "Radio(host='testhost', port=1234, timeout=2.5)"
+        expected = "Radio(host='testhost', port=1234, timeout=2.5, dry_run=False)"
         assert repr(radio) == expected
 
     def test_repr_default(self):
         """Test __repr__ with default values."""
         radio = Radio()
-        expected = "Radio(host='sts', port=9001, timeout=5.0)"
+        expected = "Radio(host='sts', port=9001, timeout=5.0, dry_run=False)"
         assert repr(radio) == expected
 
 
@@ -824,3 +824,52 @@ class TestRadioEdgeCases:
 
         # Socket should still be closed
         mock_socket.close.assert_called_once()
+
+
+class TestRadioDryRun:
+    """Tests for dry_run functionality."""
+
+    @patch("socket.socket")
+    def test_transmit_dry_run_class_level(self, mock_socket_class, sample_data):
+        """Test transmit with dry_run enabled at class level."""
+        radio = Radio(dry_run=True)
+        radio.transmit(sample_data)
+        mock_socket_class.assert_not_called()
+
+    @patch("socket.socket")
+    def test_transmit_dry_run_method_override(self, mock_socket_class, sample_data):
+        """Test transmit with dry_run enabled via method override."""
+        radio = Radio(dry_run=False)
+        radio.transmit(sample_data, dry_run=True)
+        mock_socket_class.assert_not_called()
+
+    @patch("socket.socket")
+    def test_receive_dry_run_class_level(self, mock_socket_class, sample_ids):
+        """Test receive with dry_run enabled at class level."""
+        radio = Radio(dry_run=True)
+        data = radio.receive(sample_ids)
+        assert data == []
+        mock_socket_class.assert_not_called()
+
+    @patch("socket.socket")
+    def test_receive_dry_run_method_override(self, mock_socket_class, sample_ids):
+        """Test receive with dry_run enabled via method override."""
+        radio = Radio(dry_run=False)
+        data = radio.receive(sample_ids, dry_run=True)
+        assert data == []
+        mock_socket_class.assert_not_called()
+
+    @patch("socket.socket")
+    def test_transmit_dry_run_invalid_data(self, mock_socket_class):
+        """Test transmit with dry_run still validates data."""
+        radio = Radio(dry_run=True)
+        # Create datum with invalid format by bypassing validation
+        datum = Datum.__new__(Datum)
+        datum.id = 0
+        datum.format = 6
+        datum.timestamp = 0
+        datum.value = 0
+
+        with pytest.raises(RuntimeError, match="Invalid data type"):
+            radio.transmit([datum])
+        mock_socket_class.assert_not_called()


### PR DESCRIPTION
Added dry_run capability to Radio.__init__, Radio.transmit, and Radio.receive to allow for testing the packing logic without actual network transmission.