### PR TITLE
STS-9 docs: update Jira workflow states and add transition ID table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ Keep the ticket updated with any blockers or scope changes via comments.
 - Include the ticket key in the PR title: `STS-42 fix: sensor calibration`
 - Opening a PR does **not** automatically mean the work is ready for review — further
   commits are expected.
-- Only transition the ticket to **Pending** when explicitly asked to request a
+- Only transition the ticket to **In Review** when explicitly asked to request a
   review (e.g. "request a review", "mark for review", "this is ready for review").
   If no review was requested, the ticket should remain **In Progress** until merge.
 
@@ -216,6 +216,14 @@ If the STS board protocol is extended to support a new format:
 - **Project Key:** STS
 - **Project ID:** 10099
 - **Default Issue Type:** Task (ID: 10007)
+
+### Workflow Transition IDs
+| ID | Transition | Result State |
+|----|-----------|-------------|
+| `11` | To Do | To Do |
+| `21` | In Progress | In Progress |
+| `31` | In Review | In Review |
+| `41` | Done | Done |
 
 ## Creating Jira Issues
 


### PR DESCRIPTION
Updates all three repos' AGENTS.md files to reflect the new STS Jira workflow.

**Changes:**
- `Pending` → `In Review` in the development workflow section
- Added `### Workflow Transition IDs` table to `## Project Configuration`:
  - `11` → To Do
  - `21` → In Progress
  - `31` → In Review
  - `41` → Done

Agents no longer need to look up transition IDs at runtime.

Relates to: https://subaru-naoj.atlassian.net/browse/STS-9

---
*Edited by GitHub Copilot CLI (claude-sonnet-4.6) on behalf of @wtgee*