### PR TITLE
STS-14 fix: change Radio default host from 'sts' to 'localhost'

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,7 @@ on mismatch.
 
 ### `Radio` — `src/subaru/sts/client/radio.py`
 
-The TCP client. Connects to the STS board (default `host="sts"`, `port=9001`), speaks the binary
+The TCP client. Connects to the STS board (default `host="localhost"`, `port=9001`), speaks the binary
 protocol, and exposes two public methods:
 
 - `radio.transmit(data)` — sends a list of `Datum` objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+
+### Changed
+- `Radio` default `host` changed from `"sts"` (the production server hostname) to `"localhost"` for safety. Scripts targeting the production STS board must now pass `host="sts"` explicitly.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ print(latest)
     - HOST: `localhost`
     - PORT: `9001`
     - TIMEOUT: `5.0` seconds
-    - DRY_RUN: `False`
+    - `dry_run`: `False` (constructor parameter; no class constant)
 - You can override these via the constructor:
     - `Radio(host='example.org', port=9001, timeout=2.0, dry_run=True)`
 - You can also override `dry_run` for individual transmit calls:
@@ -103,7 +103,7 @@ print(latest)
 
 - Some tests are pure unit tests (packing/unpacking, factory methods), and others perform live network I/O against the
   default STS HOST/PORT.
-- Running all tests as-is may attempt to connect to sts:9001 and may fail or hang if not reachable.
+- Running all tests as-is may attempt to connect to localhost:9001 and may fail or hang if no local STS server is running.
 
 ### Run tests
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ d5 = Datum.FloatWithText(id=1094, timestamp=now, value=(2.5, 'm/s'))
 d6 = Datum.Exponent(id=1095, timestamp=now, value=1.0)
 
 # Create a radio to broadcast/receive data.
-radio = Radio() 
+# Pass host="sts" (or your server hostname) to connect to production.
+radio = Radio()
 radio.transmit([d1, d2, d3, d4, d5, d6])
 
 # Get the lastest values by id.
@@ -89,7 +90,7 @@ print(latest)
 ## Configuration
 
 - Radio defaults (as defined in src/subaru/sts/client/radio.py):
-    - HOST: `sts`
+    - HOST: `localhost`
     - PORT: `9001`
     - TIMEOUT: `5.0` seconds
     - DRY_RUN: `False`

--- a/src/subaru/sts/client/radio.py
+++ b/src/subaru/sts/client/radio.py
@@ -11,7 +11,7 @@ class Radio:
     """A class to communicate with the STS board (STS radio)."""
 
     # Default STS server IP address and STS board TCP port number
-    HOST = "sts"
+    HOST = "localhost"
     PORT = 9001
 
     # Default timeout (seconds)

--- a/tests/test_radio.py
+++ b/tests/test_radio.py
@@ -36,7 +36,7 @@ class TestRadioInit:
     def test_default_constructor(self):
         """Test the default constructor of the Radio class."""
         radio = Radio()
-        assert radio.host == "sts"
+        assert radio.host == "localhost"
         assert radio.port == 9001
         assert radio.timeout == 5.0
 
@@ -50,14 +50,14 @@ class TestRadioInit:
     def test_constructor_with_custom_port(self):
         """Test constructor with custom port."""
         radio = Radio(port=8080)
-        assert radio.host == "sts"
+        assert radio.host == "localhost"
         assert radio.port == 8080
         assert radio.timeout == 5.0
 
     def test_constructor_with_custom_timeout(self):
         """Test constructor with custom timeout."""
         radio = Radio(timeout=10.0)
-        assert radio.host == "sts"
+        assert radio.host == "localhost"
         assert radio.port == 9001
         assert radio.timeout == 10.0
 
@@ -77,7 +77,7 @@ class TestRadioInit:
     def test_repr_default(self):
         """Test __repr__ with default values."""
         radio = Radio()
-        expected = "Radio(host='sts', port=9001, timeout=5.0, dry_run=False)"
+        expected = "Radio(host='localhost', port=9001, timeout=5.0, dry_run=False)"
         assert repr(radio) == expected
 
 
@@ -445,7 +445,7 @@ class TestRadioTransmit:
         # Verify socket operations
         mock_socket_class.assert_called_once_with(socket.AF_INET, socket.SOCK_STREAM)
         mock_socket.settimeout.assert_called_once_with(5.0)
-        mock_socket.connect.assert_called_once_with(("sts", 9001))
+        mock_socket.connect.assert_called_once_with(("localhost", 9001))
 
         # Verify commands sent
         calls = mock_socket.sendall.call_args_list
@@ -558,7 +558,7 @@ class TestRadioReceive:
 
         # Verify socket operations
         mock_socket.settimeout.assert_called_once_with(5.0)
-        mock_socket.connect.assert_called_once_with(("sts", 9001))
+        mock_socket.connect.assert_called_once_with(("localhost", 9001))
 
         # Verify read mode entered
         calls = mock_socket.sendall.call_args_list
@@ -730,7 +730,7 @@ class TestRadioConstants:
 
     def test_default_constants(self):
         """Test that class constants have expected values."""
-        assert Radio.HOST == "sts"
+        assert Radio.HOST == "localhost"
         assert Radio.PORT == 9001
         assert Radio.TIMEOUT == 5.0
 


### PR DESCRIPTION
## Summary

Defaulting to the production server hostname (`sts`) is a safety risk — any bare `Radio()` call with `dry_run=False` would silently hit production. The standard convention for client libraries is to default to `localhost` and require callers to opt in to a specific server.

## Changes

- `Radio.HOST` changed from `"sts"` to `"localhost"`
- Updated all tests asserting on the default host
- Updated README Configuration table and Quick Start example comment
- Added CHANGELOG entry

## ⚠️ Breaking change

Any script in `subaru-telemetry-server` (or elsewhere) that calls `Radio()` without an explicit `host=` argument will now connect to `localhost` instead of the production STS board. Those callers must be updated to `Radio(host="sts")`.