### PR TITLE
STS-35 docs: document internal datums 0/1/2 for connectivity testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Internal datums connectivity section** in `README.md`: Documents the three always-present datum IDs (0 = CPU load, 1 = Test1, 2 = Test2) that are pre-seeded by the Go `sts-board` daemon at startup. Includes a Python connectivity-check example using `Radio.receive` and `Radio.transmit` against these safe test targets.
+
 ### Changed
 - `Radio` default `host` changed from `"sts"` (the production server hostname) to `"localhost"` for safety. Scripts targeting the production STS board must now pass `host="sts"` explicitly.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Datum IDs 1 and 2 are the recommended targets for connectivity checks and smoke 
 import time
 from subaru.sts.client import Radio, Datum
 
-radio = Radio(host='sts')  # or 'localhost' for a local Docker board
+radio = Radio()  # defaults to localhost:9001; pass host='sts' for production
 
 # Read the board's CPU load — always available, no write needed
 cpu = radio.receive([0])

--- a/README.md
+++ b/README.md
@@ -99,6 +99,42 @@ print(latest)
 - You can also override `dry_run` for individual transmit calls:
     - `radio.transmit(data, dry_run=True)`
 
+## Internal datums — connectivity and smoke-testing
+
+The STS board always pre-seeds three datum IDs at startup that do not correspond to any physical sensor. They exist **in-memory only** — they are not rows in the MySQL `datum` table, so writes to them are not archived.
+
+| Datum ID | Name | Format | Notes |
+|---|---|---|---|
+| `0` | STSboard CPU Load | `Float` | Overwritten every 5 s by the board; client writes are accepted but immediately superseded |
+| `1` | STSboard Test1 | `IntegerWithText` | Writable; no alarm, no archival side-effects; persists in memory until board restarts |
+| `2` | STSboard Test2 | `FloatWithText` | Writable; no alarm, no archival side-effects; persists in memory until board restarts |
+
+Datum IDs 1 and 2 are the recommended targets for connectivity checks and smoke tests. Writes succeed at the protocol level and are immediately readable back via `receive()`.
+
+> **Format note:** The format byte in the transmitted packet determines how the value is stored. Pass the correct datum type — `IntegerWithText` for ID 1, `FloatWithText` for ID 2 — to ensure `receive()` returns the expected Python type.
+
+> **MySQL note:** Because these datums are not in the `datum` table, the bridge will log (and discard) a MySQL write error for each update. This is harmless and does not affect in-memory reads.
+
+### Connectivity check example
+
+```python
+import time
+from subaru.sts.client import Radio, Datum
+
+radio = Radio(host='sts')  # or 'localhost' for a local Docker board
+
+# Read the board's CPU load — always available, no write needed
+cpu = radio.receive([0])
+print('Board CPU load:', cpu[0].value)
+
+# Round-trip a write+read on the safe test datum
+now = int(time.time())
+radio.transmit([Datum.IntegerWithText(id=1, timestamp=now, value=(42, 'ok'))])
+result = radio.receive([1])
+assert result[0].value == (42, 'ok'), f"unexpected: {result[0].value}"
+print('Round-trip OK')
+```
+
 ## Tests
 
 - Some tests are pure unit tests (packing/unpacking, factory methods), and others perform live network I/O against the

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Datum IDs 1 and 2 are the recommended targets for connectivity checks and smoke 
 import time
 from subaru.sts.client import Radio, Datum
 
-radio = Radio()  # defaults to localhost:9001; pass host='sts' for production
+radio = Radio()
 
 # Read the board's CPU load — always available, no write needed
 cpu = radio.receive([0])


### PR DESCRIPTION
Adds documentation about the three always-present internal datum IDs (0, 1, 2) pre-seeded by the Go `sts-board` at startup.

## Changes

- **README.md**: New *Internal datums* section with:
  - Table of IDs 0–2 with name, format, and usage notes
  - Clarifies these are **in-memory only** — not in MySQL, so writes are not archived; bridge logs a harmless error on each update
  - Format guidance for writing (IntegerWithText for ID 1, FloatWithText for ID 2)
  - Python connectivity-check example with write + round-trip assertion
- **CHANGELOG.md**: Added entry under `[Unreleased]`

## Why

These datums are the safest targets for smoke-testing the STS protocol without touching production data. Until now this wasn't documented anywhere in the client repo.

Related: STS-35

---
*Opened by GitHub Copilot CLI (claude-sonnet-4.6) on behalf of @wtgee*